### PR TITLE
[FEATURE] Rename all references to necronizer's cloud to YASM Media

### DIFF
--- a/.github/workflows/tofu-deploy.yaml
+++ b/.github/workflows/tofu-deploy.yaml
@@ -1,4 +1,4 @@
-name: Infrastructure Deployment on Self Hosted Kubernetes Cluster
+name: YASM Infrastructure Deployment on Self Hosted Kubernetes Cluster
 
 on:
   workflow_dispatch:
@@ -16,12 +16,12 @@ on:
 
 jobs:
   infrastructure_deploy:
-    name: Infrastructure Deployment on Self Hosted Kubernetes Cluster
+    name: YASM Infrastructure Deployment on Self Hosted Kubernetes Cluster
     uses: necro-cloud/automations/.github/workflows/tofu-deploy.yml@main
     with:
-      deployment_name: Infrastructure
+      deployment_name: YASM Infrastructure
       folder_path: .
-      runners: cloud
+      runners: yasm
       pre_plan_script: tofu apply --target=module.helm -var-file terraform.tfvars.json -auto-approve
     secrets:
       KUBECONFIG: ${{ secrets.KUBECONFIG }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 PhotoAtom
+Copyright (c) 2025 YASM Media
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# necronizer's cloud guide to use OpenTofu modules
+# YASM Infrastructure
 
-This repository mainly contains OpenTofu files on how to use the [modules](https://github.com/necro-cloud/modules) for deploying a self hosted cloud solution perfect for side projects and also is used for testing out modules when new features are being worked on.
+This repository mainly contains OpenTofu configuration for deploying infrastructure for YASM Media utilizing [necronizer's cloud modules](https://github.com/necro-cloud/modules) for deploying a self hosted cloud solution.
 
 # Requirements and Dependencies
 
 The following is required to start using this repository:
 1. [OpenTofu](https://opentofu.org/) - Since modules are written in OpenTofu, we deploy all components using OpenTofu
-2. Kubernetes Cluster - Any kubernetes cluster can do, tested out with my [self hosted kubernetes cluster](https://github.com/necro-cloud/kubernetes)
+2. Kubernetes Cluster - Any kubernetes cluster can do, tested out with my [self hosted kubernetes cluster](https://github.com/YASM-Media/cluster)
 3. [Cloudflare Token and DNS Zones](https://www.cloudflare.com/) - Currently all modules use Cloudflare for provisioning public SSL certificates using DNS01 challenge validation.
 4. An SMTP Server - For sending mails using Keycloak Authentication
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   keycloak_realm_settings = {
-    display_name               = "Necronizer's Cloud"
-    application_name           = "cloud"
+    display_name               = "YASM Media"
+    application_name           = "yasm"
     base_url                   = var.keycloak_authentication_base_url
     valid_login_redirect_path  = var.keycloak_authentication_valid_login_redirect_path
     valid_logout_redirect_path = var.keycloak_authentication_valid_logout_redirect_path

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ module "minio" {
   domain              = var.domain
   cluster_issuer_name = module.cluster-issuer.cluster-issuer-name
   operator_namespace  = module.helm.minio-operator-namespace
-  users               = ["cloud"]
-  buckets             = ["cloud"]
+  users               = ["yasm"]
+  buckets             = ["yasm"]
 }
 
 module "cnpg" {
@@ -28,9 +28,9 @@ module "cnpg" {
   backup_bucket_name                = module.minio.postgres-backup-bucket
   clients = [
     {
-      namespace          = "cloud"
-      user               = "cloud"
-      database           = "cloud"
+      namespace          = "backend"
+      user               = "yasm"
+      database           = "yasm"
       derRequired        = false
       privateKeyEncoding = "PKCS1"
     }


### PR DESCRIPTION
# Proposed Changes
 - Renamed all references to necronizer's cloud to YASM Media in the README
 - Configured the required components such as Keycloak, MinIO and PostgreSQL databases with the required details
 - Made sure the pipelines are referring the correct runners

**Closes: #1**
